### PR TITLE
Name guide argument

### DIFF
--- a/R/FMEPlot.R
+++ b/R/FMEPlot.R
@@ -59,7 +59,7 @@ FMEPlotBivariate = R6::R6Class("FMEPlotBivariate",
                    #position = "identity") +
                    width = jitter[1],
                    height = jitter[2]) +
-        ggplot2::scale_fill_viridis_c(ggplot2::guide_legend("FME")) +
+        ggplot2::scale_fill_viridis_c(guide = ggplot2::guide_legend("FME")) +
         ggplot2::geom_segment(ggplot2::aes(x = (0.5 * min(x1) + 0.5 * max(x1) - 0.5 * self$step.size[1]),
                          xend = (0.5 * min(x1) + 0.5 * max(x1) + 0.5 * self$step.size[1]),
                          y = min(x2)-0.03*range.x2,
@@ -95,7 +95,7 @@ FMEPlotBivariate = R6::R6Class("FMEPlotBivariate",
                      alpha = 0.6,
                      width = jitter[1],
                      height = jitter[2]) +
-          ggplot2::scale_fill_viridis_c(ggplot2::guide_legend("NLM"),
+          ggplot2::scale_fill_viridis_c(guide = ggplot2::guide_legend("NLM"),
                                breaks=c(0.98, 0.5, 0.01),
                                labels = c("1.0", "0.5", "\u2264 0")) +
           ggplot2::geom_segment(ggplot2::aes(x = (0.5 * min(x1) + 0.5 * max(x1) - 0.5 * self$step.size[1]),


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break fmeffects.

This PR aims to prevent this from happening. Briefly, in the new ggplot2 version, an effort has been made to put the `name` argument as the first argument in scales. Unfortunately, that meant that some code in fmeffects would put an unnamed `guide_legend()` as `name` in some scales. By naming the `guide` argument, this mishap is prevented.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help fmeffects get out a fix if necessary.